### PR TITLE
Use the build version as revision version number

### DIFF
--- a/demo-angular/app/App_Resources/Android/AndroidManifest.xml
+++ b/demo-angular/app/App_Resources/Android/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="__PACKAGE__"
 	android:versionCode="1"
-	android:versionName="1.0">
+	android:versionName="1.1.1">
 
 	<supports-screens
 		android:smallScreens="true"

--- a/demo-angular/app/App_Resources/iOS/Info.plist
+++ b/demo-angular/app/App_Resources/iOS/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/demo/app/App_Resources/Android/AndroidManifest.xml
+++ b/demo/app/App_Resources/Android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="__PACKAGE__"
-	android:versionCode="123"
-	android:versionName="1.1.1.1">
+	android:versionCode="1"
+	android:versionName="1.1.1">
 
 	<supports-screens
 		android:smallScreens="true"

--- a/demo/app/App_Resources/iOS/Info.plist
+++ b/demo/app/App_Resources/iOS/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1.1</string>
+	<string>1.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>123</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/src/store-update.common.ts
+++ b/src/store-update.common.ts
@@ -6,7 +6,7 @@ import * as appSettings from 'tns-core-modules/application-settings'
 import { Observable } from 'tns-core-modules/data/observable'
 import { device } from 'tns-core-modules/platform'
 
-import { getAppIdSync, getVersionNameSync } from 'nativescript-appversion'
+import { getAppIdSync, getVersionCodeSync, getVersionNameSync } from 'nativescript-appversion'
 import { confirm, ConfirmOptions } from 'tns-core-modules/ui/dialogs'
 
 import { AlertTypesConstants, UpdateTypesConstants } from './constants'
@@ -60,7 +60,7 @@ export class StoreUpdateCommon {
   }
 
   static getLocalVersionNumber(): string {
-    return getVersionNameSync()
+    return `${getVersionNameSync()}.${getVersionCodeSync()}`
   }
 
   /*


### PR DESCRIPTION
Right now we used only app version number which contains Major, Minor, and Patch versions but we offer the ability to test revision number. To get this one we need to retrieve as well the build number.