### PR TITLE
Fix classes and iOS openStore

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -3771,78 +3771,12 @@
             "moment": "2.18.1"
           }
         },
-        "async": {
-          "version": "0.9.2",
-          "bundled": true
-        },
-        "cycle": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "deep-equal": {
-          "version": "0.2.2",
-          "bundled": true
-        },
-        "eyes": {
-          "version": "0.1.8",
-          "bundled": true
-        },
-        "i": {
-          "version": "0.3.5",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
         "moment": {
           "version": "2.18.1",
           "bundled": true
         },
-        "mute-stream": {
-          "version": "0.0.7",
-          "bundled": true
-        },
         "nativescript-appversion": {
           "version": "1.4.1",
-          "bundled": true
-        },
-        "ncp": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "pkginfo": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "prompt": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "pkginfo": "0.4.0",
-            "read": "1.0.7",
-            "revalidator": "0.1.8",
-            "utile": "0.3.0",
-            "winston": "2.1.1"
-          }
-        },
-        "read": {
-          "version": "1.0.7",
-          "bundled": true,
-          "requires": {
-            "mute-stream": "0.0.7"
-          }
-        },
-        "revalidator": {
-          "version": "0.1.8",
-          "bundled": true
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true
-        },
-        "stack-trace": {
-          "version": "0.0.10",
           "bundled": true
         },
         "tns-platform-declarations": {
@@ -3852,44 +3786,6 @@
         "typescript": {
           "version": "2.3.4",
           "bundled": true
-        },
-        "utile": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "async": "0.9.2",
-            "deep-equal": "0.2.2",
-            "i": "0.3.5",
-            "ncp": "1.0.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "winston": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "async": "1.0.0",
-            "colors": "1.0.3",
-            "cycle": "1.0.3",
-            "eyes": "0.1.8",
-            "isstream": "0.1.2",
-            "pkginfo": "0.3.1",
-            "stack-trace": "0.0.10"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "colors": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "pkginfo": {
-              "version": "0.3.1",
-              "bundled": true
-            }
-          }
         }
       }
     },

--- a/src/interfaces/app-store-result.interface.ts
+++ b/src/interfaces/app-store-result.interface.ts
@@ -4,6 +4,7 @@ export interface IAppleStoreResult {
   version: string
   minimumOsVersion: string
   currentVersionReleaseDate: string
+  trackViewUrl: string
 }
 
 /*

--- a/src/interfaces/store-update.config.interface.ts
+++ b/src/interfaces/store-update.config.interface.ts
@@ -5,4 +5,5 @@ export interface IStoreUpdateConfig {
   revisionUpdateAlertType?: number
   notifyNbDaysAfterRelease?: number
   countryCode?: string
+  onConfirmed?: any
 }

--- a/src/store-update.common.ts
+++ b/src/store-update.common.ts
@@ -26,7 +26,6 @@ const defaultConfig: IStoreUpdateConfig = {
 }
 
 export class StoreUpdateCommon {
-  instantiated = false
   countryCode
 
   private _majorUpdateAlertType

--- a/src/store-update.ios.ts
+++ b/src/store-update.ios.ts
@@ -50,7 +50,7 @@ export class StoreUpdate extends StoreUpdateCommon {
   protected static _openStore() {
     // App Path
     utils.openUrl(
-      NSURL.URLWithString(`itms-apps://itunes.com/app/${StoreUpdate.getBundleId()}`).absoluteString
+      NSURL.URLWithString(`itms-apps${StoreUpdate._trackViewUrl.slice(5)}`).absoluteString
     )
   }
 
@@ -59,6 +59,7 @@ export class StoreUpdate extends StoreUpdateCommon {
    */
 
   private static _extendResults(result: IAppleStoreResult) {
+    StoreUpdate._trackViewUrl = result.trackViewUrl
     return {
       ...result,
       systemVersion: UIDevice.currentDevice.systemVersion,

--- a/src/store-update.ios.ts
+++ b/src/store-update.ios.ts
@@ -13,8 +13,7 @@ export * from './interfaces'
 app.ios.delegate = ForegroundDelegage
 
 export class StoreUpdate extends StoreUpdateCommon {
-  private static _storeUpdateCommon
-  private static _instantiated = false
+  private static _common
   private static _trackViewUrl
 
   /*
@@ -22,24 +21,18 @@ export class StoreUpdate extends StoreUpdateCommon {
   */
 
   static init(config: IStoreUpdateConfig) {
-    if (StoreUpdate._instantiated) throw new Error('NS Store Update already configured')
-    StoreUpdate._storeUpdateCommon = new StoreUpdateCommon({
+    if (StoreUpdate._common) throw new Error('NS Store Update already configured')
+    StoreUpdate._common = new StoreUpdateCommon({
       ...config,
       onConfirmed: StoreUpdate._openStore.bind(StoreUpdate),
     })
-    StoreUpdate._instantiated = true
   }
 
   static checkForUpdate() {
-    if (!StoreUpdate._instantiated) return
-    AppStoreHelper.getAppInfos(
-      StoreUpdate._storeUpdateCommon.getBundleId(),
-      StoreUpdate._storeUpdateCommon.countryCode
-    )
+    if (!StoreUpdate._common) return
+    AppStoreHelper.getAppInfos(StoreUpdate._common.getBundleId(), StoreUpdate._common.countryCode)
       .then(StoreUpdate._extendResults)
-      .then(
-        StoreUpdate._storeUpdateCommon.triggerAlertIfEligible.bind(StoreUpdate._storeUpdateCommon)
-      )
+      .then(StoreUpdate._common.triggerAlertIfEligible.bind(StoreUpdate._common))
       .catch(e => console.error(e))
   }
 

--- a/src/store-update.ios.ts
+++ b/src/store-update.ios.ts
@@ -13,14 +13,33 @@ export * from './interfaces'
 app.ios.delegate = ForegroundDelegage
 
 export class StoreUpdate extends StoreUpdateCommon {
+  private static _storeUpdateCommon
+  private static _instantiated = false
+  private static _trackViewUrl
+
   /*
-   *  Public
-   */
+  *  Public
+  */
+
+  static init(config: IStoreUpdateConfig) {
+    if (StoreUpdate._instantiated) throw new Error('NS Store Update already configured')
+    StoreUpdate._storeUpdateCommon = new StoreUpdateCommon({
+      ...config,
+      onConfirmed: StoreUpdate._openStore.bind(StoreUpdate),
+    })
+    StoreUpdate._instantiated = true
+  }
 
   static checkForUpdate() {
-    AppStoreHelper.getAppInfos(StoreUpdate.getBundleId(), StoreUpdate._countryCode)
+    if (!StoreUpdate._instantiated) return
+    AppStoreHelper.getAppInfos(
+      StoreUpdate._storeUpdateCommon.getBundleId(),
+      StoreUpdate._storeUpdateCommon.countryCode
+    )
       .then(StoreUpdate._extendResults)
-      .then(StoreUpdate._triggerAlertIfEligible)
+      .then(
+        StoreUpdate._storeUpdateCommon.triggerAlertIfEligible.bind(StoreUpdate._storeUpdateCommon)
+      )
       .catch(e => console.error(e))
   }
 

--- a/tslint.json
+++ b/tslint.json
@@ -43,6 +43,7 @@
             "check-format",
             "allow-leading-underscore",
             "allow-pascal-case"
-        ]
+        ],
+        "object-literal-sort-keys": false
     }
 }


### PR DESCRIPTION
I've refactored both parent and child classes to use composition as it will be way easier and cleaner.
For opening iOS store, we now use the property `trackViewUrl` from the lookup file, but with replacing `https` protocol with `itms-apps`.
Also disabled the alphabetical sorting rule of tslint as it can be cumbersome in the case where you want a cleaner or easier reading order for parameters or properties.