### PR TITLE
Allow dialog message overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Translations are handled via json files which are located in `src/i18n` folder a
 | **revisionUpdateAlertType** | NONE | Alert type for revision version change (e.g: a.b.c.D) |
 | **notifyNbDaysAfterRelease** | `1` | Delays the update prompt by a specific number of days |
 | **countryCode** | `en` | country store code |
+| **alertOptions** | AlertOptions | Customize alert dialog text, bypasses the Locale json |
 
 ### Alert types
 | Key | Value | Description |
@@ -55,6 +56,15 @@ Translations are handled via json files which are located in `src/i18n` folder a
 | **FORCE** | `1` | Show an alert that can't be skipped |
 | **OPTION** | `2` | Show an alert that can be skipped |
 | **NONE** | `3` | Don't display alert at all |
+
+### AlertOptions configuration
+| Property | Default | Description |
+| --- | --- | --- |
+| **custom** | false | Use custom alerts |
+| **title** | LocaleText | Dialog title, fallback to the local json |
+| **message** | LocaleText | Dialog body text, fallback to the local json |
+| **updateButton** | LocaleText | Dialog update button, fallback to the local json |
+| **skipButton** | LocaleText | Dialog skip button, fallback to the local json |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Translations are handled via json files which are located in `src/i18n` folder a
 | **revisionUpdateAlertType** | NONE | Alert type for revision version change (e.g: a.b.c.D) |
 | **notifyNbDaysAfterRelease** | `1` | Delays the update prompt by a specific number of days |
 | **countryCode** | `en` | country store code |
-| **alertOptions** | AlertOptions | Customize alert dialog text, bypasses the Locale json |
+| **alertOptions** | null | Customize alert dialog text, bypasses the Locale json |
 
 ### Alert types
 | Key | Value | Description |
@@ -57,10 +57,9 @@ Translations are handled via json files which are located in `src/i18n` folder a
 | **OPTION** | `2` | Show an alert that can be skipped |
 | **NONE** | `3` | Don't display alert at all |
 
-### AlertOptions configuration
+### AlertOptions configuration (Optional)
 | Property | Default | Description |
 | --- | --- | --- |
-| **custom** | false | Use custom alerts |
 | **title** | LocaleText | Dialog title, fallback to the local json |
 | **message** | LocaleText | Dialog body text, fallback to the local json |
 | **updateButton** | LocaleText | Dialog update button, fallback to the local json |

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -5,24 +5,23 @@ import './bundle-config'
 import { AlertTypesConstants, StoreUpdate } from 'nativescript-store-update'
 import * as application from 'tns-core-modules/application'
 
-
+/*
 StoreUpdate.init({
   majorUpdateAlertType: AlertTypesConstants.OPTION,
   notifyNbDaysAfterRelease: 1,
 })
+*/
 
-/*
 //Custom message testing
 StoreUpdate.init({
   majorUpdateAlertType: AlertTypesConstants.OPTION,
   notifyNbDaysAfterRelease: 1,
   alertOptions: {
-    custom: true,
     title: "Attention",
     //message: "Your app is busted out of date",
     //updateButton: "Update now",
     skipButton: "Skip" //Ignoring, testing fallback to Localehelper
   }
 })
-*/
+
 application.start({ moduleName: 'main-page' })

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -5,8 +5,24 @@ import './bundle-config'
 import { AlertTypesConstants, StoreUpdate } from 'nativescript-store-update'
 import * as application from 'tns-core-modules/application'
 
+
 StoreUpdate.init({
   majorUpdateAlertType: AlertTypesConstants.OPTION,
   notifyNbDaysAfterRelease: 1,
 })
+
+/*
+//Custom message testing
+StoreUpdate.init({
+  majorUpdateAlertType: AlertTypesConstants.OPTION,
+  notifyNbDaysAfterRelease: 1,
+  alertOptions: {
+    custom: true,
+    title: "Attention",
+    //message: "Your app is busted out of date",
+    //updateButton: "Update now",
+    skipButton: "Skip" //Ignoring, testing fallback to Localehelper
+  }
+})
+*/
 application.start({ moduleName: 'main-page' })

--- a/src/interfaces/store-update.config.interface.ts
+++ b/src/interfaces/store-update.config.interface.ts
@@ -6,4 +6,13 @@ export interface IStoreUpdateConfig {
   notifyNbDaysAfterRelease?: number
   countryCode?: string
   onConfirmed?: any
+  alertOptions?: AlertOptions
+}
+
+export interface AlertOptions {
+  custom? :boolean,
+  title?: string,
+  message?: string,
+  updateButton?: string,
+  skipButton?: string
 }

--- a/src/interfaces/store-update.config.interface.ts
+++ b/src/interfaces/store-update.config.interface.ts
@@ -10,7 +10,6 @@ export interface IStoreUpdateConfig {
 }
 
 export interface AlertOptions {
-  custom? :boolean,
   title?: string,
   message?: string,
   updateButton?: string,

--- a/src/store-update.common.ts
+++ b/src/store-update.common.ts
@@ -107,7 +107,7 @@ export class StoreUpdateCommon {
   buildDialogOptions({ skippable = true } = {}): ConfirmOptions {
     let options = {
       title: this._getMessage('title', 'ALERT_TITLE'),
-      message: this._getMessage("message", 'ALERT_MESSAGE'),
+      message: this._getMessage('message', 'ALERT_MESSAGE'),
       neutralButtonText: null,
       okButtonText: this._getMessage('updateButton', 'ALERT_UPDATE_BUTTON'),
     }
@@ -127,7 +127,7 @@ export class StoreUpdateCommon {
   }
 
   private _hasValidAlertOptionEntry(key) {
-    if (!this._alertOptions)  return false
+    if (!this._alertOptions) return false
     return this._alertOptions.hasOwnProperty(key) && this._alertOptions[key] !== ''
   }
 

--- a/src/store-update.common.ts
+++ b/src/store-update.common.ts
@@ -22,9 +22,7 @@ const defaultConfig: IStoreUpdateConfig = {
   notifyNbDaysAfterRelease: 1,
   patchUpdateAlertType: AlertTypesConstants.NONE,
   revisionUpdateAlertType: AlertTypesConstants.NONE,
-  alertOptions: {
-    custom: false
-  },
+  alertOptions: null,
   onConfirmed: () => console.log('User confirmed!'),
 }
 
@@ -108,28 +106,29 @@ export class StoreUpdateCommon {
 
   buildDialogOptions({ skippable = true } = {}): ConfirmOptions {
     let options = {
-      message: this.getMessage(this._alertOptions.message, LocalesHelper.translate('ALERT_MESSAGE')),
+      title: this._getMessage('title', 'ALERT_TITLE'),
+      message: this._getMessage("message", 'ALERT_MESSAGE'),
       neutralButtonText: null,
-      okButtonText: this.getMessage(this._alertOptions.updateButton, LocalesHelper.translate('ALERT_UPDATE_BUTTON')),
-      title: this.getMessage(this._alertOptions.title, LocalesHelper.translate('ALERT_TITLE')),
+      okButtonText: this._getMessage('updateButton', 'ALERT_UPDATE_BUTTON'),
     }
 
     if (skippable) {
       options = {
         ...options,
-        neutralButtonText: this.getMessage(this._alertOptions.skipButton, LocalesHelper.translate('ALERT_SKIP_BUTTON')),
+        neutralButtonText: this._getMessage('skipButton', 'ALERT_SKIP_BUTTON'),
       }
     }
 
     return options
   }
 
-  getMessage(text: string, fallback: string): string {
-    if (this._alertOptions && this._alertOptions.custom) {
-      return (text == "" || !text) ? fallback : text; //If the custom alert text is not set, return the fallback
-    } else {
-      return fallback;
-    }
+  private _getMessage(alertOptionKey: string, fallbackTranslateKey: string): string {
+    return this._hasValidAlertOptionEntry(alertOptionKey) ? this._alertOptions[alertOptionKey] : LocalesHelper.translate(fallbackTranslateKey)
+  }
+
+  private _hasValidAlertOptionEntry(key) {
+    if (!this._alertOptions)  return false
+    return this._alertOptions.hasOwnProperty(key) && this._alertOptions[key] !== ''
   }
 
   showAlertForUpdate(version: string): Promise<boolean> {


### PR DESCRIPTION
Created new alertOptions property to allow the user to override the LocaleHelper json content... falls back to the LocaleHelper verbage if nothing is set, not sure if you want to make THAT also toggleable or not... but this seems to work.

Also I wasn't sure how you want to test it so I just left it commented out in demo/app.ts